### PR TITLE
Unify header nav and add out-of-stock handling

### DIFF
--- a/client/feature/product-details/component/header.tsx
+++ b/client/feature/product-details/component/header.tsx
@@ -1,15 +1,10 @@
 "use client";
 
-import { Heart, ArrowLeft, Share2 } from "lucide-react";
+import { ArrowLeft, Search, ShoppingCart, User } from "lucide-react";
 import Link from "next/link";
+import { SignedIn, SignedOut, UserButton } from "@clerk/nextjs";
 
-interface HeaderProps {
-  productName: string;
-  isFavorite: boolean;
-  onToggleFavorite: () => void;
-}
-
-const Header = ({ productName, isFavorite, onToggleFavorite }: HeaderProps) => {
+const Header = () => {
   return (
     <div className="border-b border-border bg-background/95 backdrop-blur-sm sticky top-0 z-40">
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-4">
@@ -21,20 +16,31 @@ const Header = ({ productName, isFavorite, onToggleFavorite }: HeaderProps) => {
             <ArrowLeft className="w-4 h-4 mr-2 group-hover:-translate-x-1 transition-transform" />
             Back to Products
           </Link>
-          <div className="flex items-center space-x-2">
-            <button className="p-2 hover:bg-secondary rounded-lg transition-colors">
-              <Share2 className="w-5 h-5" />
-            </button>
-            <button
-              onClick={onToggleFavorite}
-              className="p-2 hover:bg-secondary rounded-lg transition-colors"
-            >
-              <Heart
-                className={`w-5 h-5 ${
-                  isFavorite ? "fill-accent text-accent" : "text-foreground"
-                }`}
+          <div className="flex items-center space-x-4">
+            <Search className="w-5 h-5 cursor-pointer hover:text-muted-foreground transition" />
+
+            <SignedIn>
+              <Link href="/dashboard">
+                <User className="w-5 h-5 cursor-pointer hover:text-muted-foreground transition" />
+              </Link>
+              <UserButton
+                appearance={{
+                  elements: {
+                    avatarBox: "w-8 h-8",
+                  },
+                }}
               />
-            </button>
+            </SignedIn>
+
+            <SignedOut>
+              <Link href="/auth/sign-in">
+                <User className="w-5 h-5 cursor-pointer hover:text-muted-foreground transition" />
+              </Link>
+            </SignedOut>
+
+            <Link href="/cart">
+              <ShoppingCart className="w-5 h-5 cursor-pointer hover:text-muted-foreground transition" />
+            </Link>
           </div>
         </div>
       </div>

--- a/client/feature/product-details/view/product-detail-view.tsx
+++ b/client/feature/product-details/view/product-detail-view.tsx
@@ -10,6 +10,8 @@ import {
   Truck,
   RefreshCw,
   Gift,
+  Share2,
+  Heart,
 } from "lucide-react";
 import Header from "../component/header";
 import Gallery from "../component/gallery";
@@ -160,11 +162,7 @@ export const ProductDetailView = ({
   return (
     <div className="min-h-screen bg-background">
       {/* Header */}
-      <Header
-        productName={toStringOrEmpty(data?.name)}
-        isFavorite={isFavorite}
-        onToggleFavorite={() => setIsFavorite(!isFavorite)}
-      />
+      <Header />
 
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
         <div className="grid grid-cols-1 lg:grid-cols-2 gap-12">
@@ -201,9 +199,26 @@ export const ProductDetailView = ({
                   </span>
                 </div>
               </div>
-              <h1 className="text-3xl font-light tracking-tight text-foreground mb-4">
-                {toStringOrEmpty(data?.name)}
-              </h1>
+              <div className="flex items-start justify-between mb-4">
+                <h1 className="text-3xl font-light tracking-tight text-foreground">
+                  {toStringOrEmpty(data?.name)}
+                </h1>
+                <div className="flex items-center space-x-2 ml-4">
+                  <button className="p-2 hover:bg-secondary rounded-lg transition-colors">
+                    <Share2 className="w-5 h-5" />
+                  </button>
+                  <button
+                    onClick={() => setIsFavorite(!isFavorite)}
+                    className="p-2 hover:bg-secondary rounded-lg transition-colors"
+                  >
+                    <Heart
+                      className={`w-5 h-5 ${
+                        isFavorite ? "fill-accent text-accent" : "text-foreground"
+                      }`}
+                    />
+                  </button>
+                </div>
+              </div>
 
               <div className="flex items-center space-x-3 mb-6">
                 <span className="text-2xl font-medium text-accent">
@@ -221,22 +236,28 @@ export const ProductDetailView = ({
             <div>
               <h3 className="text-sm font-medium text-foreground mb-3">Size</h3>
               <div className="flex space-x-2">
-                {variants.map((variant) => (
-                  <button
-                    onClick={() => {
-                      handleVariantSelect(variant.id);
-                    }}
-                    className={cn(
-                      "px-4 py-2 border rounded-lg text-sm font-medium transition-colors",
-                      selectedVariantId === variant.id
-                        ? "border-primary bg-primary text-primary-foreground"
-                        : "border-input bg-background text-foreground hover:bg-secondary"
-                    )}
-                    key={variant.id}
-                  >
-                    {variant.name}
-                  </button>
-                ))}
+                {variants.map((variant) => {
+                  const isOutOfStock = (variant.inventory ?? 0) <= 0;
+                  return (
+                    <button
+                      onClick={() => {
+                        handleVariantSelect(variant.id);
+                      }}
+                      className={cn(
+                        "px-4 py-2 border rounded-lg text-sm font-medium transition-colors",
+                        isOutOfStock
+                          ? "border-muted bg-muted text-muted-foreground cursor-not-allowed"
+                          : selectedVariantId === variant.id
+                          ? "border-primary bg-primary text-primary-foreground"
+                          : "border-input bg-background text-foreground hover:bg-secondary"
+                      )}
+                      key={variant.id}
+                      disabled={isOutOfStock}
+                    >
+                      {variant.name}
+                    </button>
+                  );
+                })}
               </div>
             </div>
 
@@ -245,44 +266,54 @@ export const ProductDetailView = ({
               <div>
                 <h3 className="text-sm font-medium text-foreground mb-3">
                   Quantity
+                  <span className="text-sm text-muted-foreground font-normal ml-2">
+                    ({selectedVariant?.inventory ?? 0} in stock)
+                  </span>
                 </h3>
                 <div className="flex items-center space-x-4">
-                  <div className="flex items-center border border-input rounded-lg">
+                  <div className={cn(
+                    "flex items-center border rounded-lg",
+                    (selectedVariant?.inventory ?? 0) <= 0 ? "border-muted bg-muted/50" : "border-input"
+                  )}>
                     <button
                       onClick={() => handleQuantityChange(-1)}
-                      className="p-2 hover:bg-secondary transition-colors"
-                      disabled={quantity <= 1}
+                      className="p-2 hover:bg-secondary transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+                      disabled={(selectedVariant?.inventory ?? 0) <= 0 || quantity <= 1}
                     >
                       <Minus className="w-4 h-4" />
                     </button>
-                    <span className="px-4 py-2 font-medium">{quantity}</span>
+                    <span className="px-4 py-2 font-medium">
+                      {(selectedVariant?.inventory ?? 0) <= 0 ? 0 : quantity}
+                    </span>
                     <button
                       onClick={() => handleQuantityChange(1)}
-                      className="p-2 hover:bg-secondary transition-colors"
-                      // disabled={quantity >= product.stockCount} // 之后再确定是否需要这个部分
+                      className="p-2 hover:bg-secondary transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+                      disabled={(selectedVariant?.inventory ?? 0) <= 0 || quantity >= (selectedVariant?.inventory ?? 0)}
                     >
                       <Plus className="w-4 h-4" />
                     </button>
                   </div>
-                  <span className="text-sm text-muted-foreground">
-                    {/* {product.stockCount} in stock */}
-                  </span>
                 </div>
               </div>
 
               <div className="flex space-x-3">
                 <button
-                  className="flex-1 bg-primary text-primary-foreground py-3 px-6 rounded-lg font-medium hover:bg-primary/90 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 transition-all transform hover:scale-[1.02] active:scale-[0.98] flex items-center justify-center space-x-2"
+                  className={cn(
+                    "flex-1 py-3 px-6 rounded-lg font-medium focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 transition-all flex items-center justify-center space-x-2",
+                    (selectedVariant?.inventory ?? 0) > 0
+                      ? "bg-primary text-primary-foreground hover:bg-primary/90 transform hover:scale-[1.02] active:scale-[0.98]"
+                      : "bg-muted text-muted-foreground cursor-not-allowed"
+                  )}
                   onClick={() =>
                     handleAddingToCart({
                       variantId: selectedVariantId,
-
                       quantity,
                     })
                   }
+                  disabled={(selectedVariant?.inventory ?? 0) <= 0}
                 >
                   <ShoppingCart className="w-5 h-5" />
-                  <span>Add to Cart</span>
+                  <span>{(selectedVariant?.inventory ?? 0) > 0 ? "Add to Cart" : "Out of Stock"}</span>
                 </button>
                 {/* <button className="px-6 py-3 border border-input rounded-lg font-medium hover:bg-secondary transition-colors">
                   <Gift className="w-5 h-5" />

--- a/client/feature/product-list/components/page-header.tsx
+++ b/client/feature/product-list/components/page-header.tsx
@@ -1,17 +1,14 @@
 "use client";
 
 import Link from "next/link";
-import { ArrowLeft, Grid, List, SlidersHorizontal } from "lucide-react";
+import { ArrowLeft, Search, ShoppingCart, User, SlidersHorizontal } from "lucide-react";
+import { SignedIn, SignedOut, UserButton } from "@clerk/nextjs";
 
 interface PageHeaderProps {
-  viewMode: "grid" | "list";
-  onViewModeChange: (mode: "grid" | "list") => void;
   onToggleFilters: () => void;
 }
 
 const PageHeader = ({
-  viewMode,
-  onViewModeChange,
   onToggleFilters,
 }: PageHeaderProps) => {
   return (
@@ -31,19 +28,31 @@ const PageHeader = ({
               Our Collection
             </h1>
           </div>
-          <div className="flex items-center space-x-2">
-            <button
-              onClick={() =>
-                onViewModeChange(viewMode === "grid" ? "list" : "grid")
-              }
-              className="p-2 hover:bg-secondary rounded-lg transition-colors"
-            >
-              {viewMode === "grid" ? (
-                <List className="w-5 h-5" />
-              ) : (
-                <Grid className="w-5 h-5" />
-              )}
-            </button>
+          <div className="flex items-center space-x-4">
+            <Search className="w-5 h-5 cursor-pointer hover:text-muted-foreground transition" />
+
+            <SignedIn>
+              <Link href="/dashboard">
+                <User className="w-5 h-5 cursor-pointer hover:text-muted-foreground transition" />
+              </Link>
+              <UserButton
+                appearance={{
+                  elements: {
+                    avatarBox: "w-8 h-8",
+                  },
+                }}
+              />
+            </SignedIn>
+
+            <SignedOut>
+              <Link href="/auth/sign-in">
+                <User className="w-5 h-5 cursor-pointer hover:text-muted-foreground transition" />
+              </Link>
+            </SignedOut>
+
+            <Link href="/cart">
+              <ShoppingCart className="w-5 h-5 cursor-pointer hover:text-muted-foreground transition" />
+            </Link>
 
             <button
               onClick={onToggleFilters}

--- a/client/feature/product-list/components/product-grid-display.tsx
+++ b/client/feature/product-list/components/product-grid-display.tsx
@@ -5,6 +5,7 @@ import { Heart, ShoppingCart } from "lucide-react";
 import { products } from "@prisma/client";
 import { ProductWithVariants } from "@/types/prisma";
 import { linkToProductDetail } from "@/utils";
+import { cn } from "@/lib/utils";
 
 interface ProductGridDisplayProps {
   products: ProductWithVariants[];
@@ -18,6 +19,8 @@ const ProductGridDisplay = ({ products }: ProductGridDisplayProps) => {
         const defaultVariant = variants.find((item) => item.isDefault === true);
         const price = defaultVariant?.price || 0;
         const comparePrice = defaultVariant?.compareAtPrice;
+        const totalInventory = variants.reduce((sum, v) => sum + (v.inventory ?? 0), 0);
+        const isOutOfStock = totalInventory <= 0;
 
         return (
           <Link
@@ -29,8 +32,18 @@ const ProductGridDisplay = ({ products }: ProductGridDisplayProps) => {
               <img
                 src={product.thumbnail || "/placeholder.jpg"}
                 alt={product.name}
-                className="w-full h-full object-cover group-hover:scale-105 transition-transform duration-300"
+                className={cn(
+                  "w-full h-full object-cover transition-transform duration-300",
+                  isOutOfStock ? "grayscale" : "group-hover:scale-105"
+                )}
               />
+              {isOutOfStock && (
+                <div className="absolute inset-0 flex items-center justify-center bg-black/40">
+                  <span className="text-white font-medium text-lg px-4 py-2 bg-black/60 rounded-lg">
+                    Out of Stock
+                  </span>
+                </div>
+              )}
               {/* {product.sale && (
               <div className="absolute top-3 left-3 bg-accent text-accent-foreground px-2 py-1 rounded-full text-xs font-medium">
                 Sale

--- a/client/feature/product-list/components/product-list-display.tsx
+++ b/client/feature/product-list/components/product-list-display.tsx
@@ -4,6 +4,7 @@ import Link from "next/link";
 import { Heart, ShoppingCart } from "lucide-react";
 import { ProductWithVariants } from "@/types/prisma";
 import { linkToProductDetail } from "@/utils";
+import { cn } from "@/lib/utils";
 
 interface ProductListDisplayProps {
   products: ProductWithVariants[];
@@ -17,6 +18,8 @@ const ProductListDisplay = ({ products }: ProductListDisplayProps) => {
         const defaultVariant = variants.find((item) => item.isDefault === true);
         const price = defaultVariant?.price || 0;
         const comparePrice = defaultVariant?.compareAtPrice || 0;
+        const totalInventory = variants.reduce((sum, v) => sum + (v.inventory ?? 0), 0);
+        const isOutOfStock = totalInventory <= 0;
         return (
           <Link
             key={product.id}
@@ -27,8 +30,18 @@ const ProductListDisplay = ({ products }: ProductListDisplayProps) => {
               <img
                 src={product.thumbnail || "placeholder.jpg"}
                 alt={product.name}
-                className="w-full h-full object-cover"
+                className={cn(
+                  "w-full h-full object-cover",
+                  isOutOfStock && "grayscale"
+                )}
               />
+              {isOutOfStock && (
+                <div className="absolute inset-0 flex items-center justify-center bg-black/40">
+                  <span className="text-white font-medium text-xs px-1 py-0.5 bg-black/60 rounded">
+                    Out of Stock
+                  </span>
+                </div>
+              )}
               {/* {product.sale && (
                 <div className="absolute top-1 left-1 bg-accent text-accent-foreground px-1 py-0.5 rounded text-xs font-medium">
                   Sale

--- a/client/feature/product-list/components/results-header.tsx
+++ b/client/feature/product-list/components/results-header.tsx
@@ -1,11 +1,15 @@
 "use client";
 
+import { Grid, List } from "lucide-react";
+
 interface ResultsHeaderProps {
   filteredProductsCount: number;
   totalProductsCount: number;
   sortBy: string;
   onSortChange: (value: string) => void;
   sortOptions: Array<{ id: string; name: string }>;
+  viewMode: "grid" | "list";
+  onViewModeChange: (mode: "grid" | "list") => void;
 }
 
 const ResultsHeader = ({
@@ -14,6 +18,8 @@ const ResultsHeader = ({
   sortBy,
   onSortChange,
   sortOptions,
+  viewMode,
+  onViewModeChange,
 }: ResultsHeaderProps) => {
   return (
     <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between mb-6 gap-4">
@@ -34,6 +40,18 @@ const ResultsHeader = ({
             </option>
           ))}
         </select>
+        <button
+          onClick={() =>
+            onViewModeChange(viewMode === "grid" ? "list" : "grid")
+          }
+          className="p-2 hover:bg-secondary rounded-lg transition-colors"
+        >
+          {viewMode === "grid" ? (
+            <List className="w-5 h-5" />
+          ) : (
+            <Grid className="w-5 h-5" />
+          )}
+        </button>
       </div>
     </div>
   );

--- a/client/feature/product-list/views/product-list-view.tsx
+++ b/client/feature/product-list/views/product-list-view.tsx
@@ -91,8 +91,6 @@ export function ProductListView() {
   return (
     <div className="min-h-screen bg-background">
       <PageHeader
-        viewMode={viewMode}
-        onViewModeChange={handleViewModeChange}
         onToggleFilters={handleToggleFilters}
       />
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
@@ -116,6 +114,8 @@ export function ProductListView() {
               sortBy={sortBy}
               onSortChange={handleSortChange}
               sortOptions={sortOptions}
+              viewMode={viewMode}
+              onViewModeChange={handleViewModeChange}
             />
             <ProductDisplay
               isLoading={isLoading}


### PR DESCRIPTION
- Unify product-details and product-list headers with a shared nav (Search, Clerk auth, Cart) and move the grid/list view-mode toggle into ResultsHeader
- Add out-of-stock handling: disable size/quantity/add-to-cart on zero-inventory variants, and grayscale + badge thumbnails on the list/grid views