### PR TITLE
fix: serialize Decimal as plain numbers across product action boundary

### DIFF
--- a/client/app/actions/product.actions.ts
+++ b/client/app/actions/product.actions.ts
@@ -3,15 +3,43 @@
 import { CategoryRepo } from "@/repo";
 import { ProductRepo } from "@/repo/product.repo";
 
-function serializeProducts<T>(products: T): T {
-  return JSON.parse(
-    JSON.stringify(products, (key, value) => {
-      if (typeof value === "object" && value !== null && "toJSON" in value) {
-        return value.toJSON();
-      }
-      return value;
-    }),
+/**
+ * Deep convert a Prisma-shaped object tree into plain JS values safe to send
+ * across the React Server Components / Server Actions boundary.
+ *
+ * - Decimal → number
+ * - Date → ISO string
+ * - everything else: walked recursively
+ */
+function isDecimalLike(v: unknown): boolean {
+  if (!v || typeof v !== "object") return false;
+  const o = v as Record<string, unknown>;
+  return (
+    typeof (o as { toNumber?: unknown }).toNumber === "function" &&
+    typeof (o as { toString?: unknown }).toString === "function" &&
+    typeof (o as { s?: unknown }).s === "number"
   );
+}
+
+function serializeProducts<T>(value: T): T {
+  if (value === null || value === undefined) return value;
+  if (Array.isArray(value)) {
+    return value.map((v) => serializeProducts(v)) as unknown as T;
+  }
+  if (value instanceof Date) {
+    return value.toISOString() as unknown as T;
+  }
+  if (isDecimalLike(value)) {
+    return Number((value as { toString: () => string }).toString()) as unknown as T;
+  }
+  if (typeof value === "object") {
+    const out: Record<string, unknown> = {};
+    for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
+      out[k] = serializeProducts(v);
+    }
+    return out as unknown as T;
+  }
+  return value;
 }
 
 export async function getHotProductsAction(limit: number) {


### PR DESCRIPTION
Replace the legacy JSON.stringify-based helper with an explicit deep walker that converts Prisma Decimal instances to numbers and Dates to ISO strings, eliminating the "Decimal objects are not supported" error when product variants cross the Server / Client boundary.